### PR TITLE
chore(release): 1.0.0 [skip ci]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@orrlev/lumigo-node-wrapper",
-  "version": "0.2.10",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orrlev/lumigo-node-wrapper",
-  "version": "0.2.10",
+  "version": "1.0.0",
   "description": "Lumigo wrapper to trace distributed architecture",
   "main": "lib/src/wrapper.js",
   "private": false,
@@ -70,7 +70,9 @@
     "webpack-cli": "^3.3.4"
   },
   "release": {
-    "branches": ["master"],
+    "branches": [
+      "master"
+    ],
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",


### PR DESCRIPTION
# 1.0.0 (2022-03-08)

### Features

* first commit ([ca41874](https://github.com/lumigo-io/lumigo-node-wrapper/commit/ca418740349fa8f6f1017f289f8bfd6883df3196))