### PR TITLE
chore: refactor instrumentation activation, lint some tests

### DIFF
--- a/src/instrumentations/express/ExpressInstrumentation.ts
+++ b/src/instrumentations/express/ExpressInstrumentation.ts
@@ -3,7 +3,7 @@ import { ExpressInstrumentation } from 'opentelemetry-instrumentation-express';
 import { Instrumentor } from '../instrumentor';
 
 export default class LumigoExpressInstrumentation extends Instrumentor<ExpressInstrumentation> {
-  getInstrumentationId(): string {
+  getInstrumentedModule(): string {
     return 'express';
   }
 

--- a/src/instrumentations/express/express.ts
+++ b/src/instrumentations/express/express.ts
@@ -28,7 +28,7 @@ export const ExpressHooks: InstrumentationIfc<ExpressRequestType, any> = {
         // eslint-disable-next-line prefer-rest-params
         const origRes = oldResEnd.apply(res, arguments);
         if (res.getHeaders())
-          span.setAttribute('http.response.headers', JSON.stringify(res.getHeaders()));
+          span.setAttribute('http.response.headers', JSON.stringify(res.getHeaders())); // TODO This is not compliant with the HTTP semantic conventions
         if (response) span.setAttribute('http.response.body', JSON.stringify(response));
         if (req.body) span.setAttribute('http.request.body', JSON.stringify(req.body));
         res.end = oldResEnd;

--- a/src/instrumentations/express/expressInstrumentation.test.js
+++ b/src/instrumentations/express/expressInstrumentation.test.js
@@ -3,8 +3,8 @@ import LumigoExpressInstrumentation from './ExpressInstrumentation';
 describe('LumigoExpressInstrumentation', () => {
   let lumigoExpressInstrumentation = new LumigoExpressInstrumentation();
 
-  test('getInstrumentationId should return "express"', () => {
-    expect(lumigoExpressInstrumentation.getInstrumentationId()).toEqual('express');
+  test('getInstrumentedModule should return "express"', () => {
+    expect(lumigoExpressInstrumentation.getInstrumentedModule()).toEqual('express');
   });
 
   test('getInstrumentation should return ExpressInstrumentation object', () => {

--- a/src/instrumentations/https/httpInstrumentation.test.js
+++ b/src/instrumentations/https/httpInstrumentation.test.js
@@ -1,66 +1,13 @@
 import LumigoHttpInstrumentation from './HttpInstrumentation';
-import http from 'http';
 
 describe('LumigoHttpInstrumentation', () => {
   let lumigoHttpInstrumentation = new LumigoHttpInstrumentation();
 
-  test('getInstrumentationId should return "http"', () => {
-    expect(lumigoHttpInstrumentation.getInstrumentationId()).toEqual('http');
+  test('getInstrumentedModule should return "http"', () => {
+    expect(lumigoHttpInstrumentation.getInstrumentedModule()).toEqual('http');
   });
 
-  test('getInstrumentation should return HttpInstrumentation object', () => {
-    const ignoreConfig = [/169\.254\.\d+\.\d+.*/gm];
-
-    expect(lumigoHttpInstrumentation.getInstrumentation()).toMatchObject({
-      instrumentationName: '@opentelemetry/instrumentation-http',
-      instrumentationVersion: expect.any(String),
-      _config: {
-        enabled: true,
-        ignoreOutgoingUrls: expect.arrayContaining(ignoreConfig),
-        ignoreIncomingPaths: [],
-      },
-      _diag: {
-        _namespace: '@opentelemetry/instrumentation-http',
-      },
-      _tracer: {
-        _provider: {},
-        name: '@opentelemetry/instrumentation-http',
-        version: expect.any(String),
-      },
-      _meter: {},
-      _hooks: [
-        {
-          cache: {},
-          _unhooked: false,
-        },
-        {
-          cache: {},
-          _unhooked: false,
-        },
-      ],
-      _enabled: true,
-      _modules: [
-        {
-          name: 'https',
-          supportedVersions: ['*'],
-          files: [],
-        },
-        {
-          name: 'http',
-          supportedVersions: ['*'],
-          files: [],
-        },
-      ],
-      _spanNotEnded: {},
-      _version: expect.any(String),
-      _headerCapture: {
-        client: {},
-        server: {},
-      },
-    });
-  });
-
-  test('requireIfAvailable should return required name', () => {
+  test('requireIfAvailable should return the "http" module', () => {
     const http = require('http');
     expect(lumigoHttpInstrumentation.requireIfAvailable()).toEqual(http);
   });

--- a/src/instrumentations/instrumentor.ts
+++ b/src/instrumentations/instrumentor.ts
@@ -1,10 +1,13 @@
-import { safeRequire } from '../utils';
+import { canRequireModule, safeRequire } from '../utils';
 
 export abstract class Instrumentor<T> {
-  abstract getInstrumentationId(): string;
+  abstract getInstrumentedModule(): string;
+
   abstract getInstrumentation(options?): T;
 
+  isApplicable = () => canRequireModule(this.getInstrumentedModule());
+
   requireIfAvailable(): string {
-    return safeRequire(this.getInstrumentationId());
+    return safeRequire(this.getInstrumentedModule());
   }
 }

--- a/src/instrumentations/mongodb/MongoDBInstrumentation.ts
+++ b/src/instrumentations/mongodb/MongoDBInstrumentation.ts
@@ -2,7 +2,7 @@ import { MongoDBInstrumentation } from '@opentelemetry/instrumentation-mongodb';
 import { Instrumentor } from '../instrumentor';
 
 export default class LumigoMongoDBInstrumentation extends Instrumentor<MongoDBInstrumentation> {
-  getInstrumentationId(): string {
+  getInstrumentedModule(): string {
     return 'mongodb';
   }
 

--- a/src/instrumentations/mongodb/mongoDBInstrumentation.test.js
+++ b/src/instrumentations/mongodb/mongoDBInstrumentation.test.js
@@ -7,8 +7,8 @@ describe('LumigoMongoDBInstrumentation', () => {
 
   let lumigoMongoDBInstrumentation = new LumigoMongoDBInstrumentation();
 
-  test('getInstrumentationId should return "mongodb"', () => {
-    expect(lumigoMongoDBInstrumentation.getInstrumentationId()).toEqual('mongodb');
+  test('getInstrumentedModule should return "mongodb"', () => {
+    expect(lumigoMongoDBInstrumentation.getInstrumentedModule()).toEqual('mongodb');
   });
 
   test('getInstrumentation should return MongoDBInstrumentation object', () => {

--- a/test/integration/mongodb/mongodb.test.js
+++ b/test/integration/mongodb/mongodb.test.js
@@ -1,27 +1,27 @@
-const {test, describe} = require("../setup");
-const fs = require("fs");
+const {test, describe} = require('../setup');
+const fs = require('fs');
 const waitOn = require('wait-on')
-require("jest-json");
+require('jest-json');
 
-const {waitForSpansInFile} = require("../../testUtils/waiters");
-const kill = require("tree-kill");
+const {waitForSpansInFile} = require('../../testUtils/waiters');
+const kill = require('tree-kill');
 const {
     getInstrumentationSpansFromFile, getSpanByName, getFilteredSpans, getExpectedResourceAttributes, getExpectedSpan,
     getExpectedSpanWithParent
-} = require("./mongodbTestUtils");
-const {callContainer, getStartedApp, getAppPort} = require("../../testUtils/utils");
+} = require('./mongodbTestUtils');
+const {callContainer, getStartedApp, getAppPort} = require('../../testUtils/utils');
 
 const SPANS_DIR = `${__dirname}/spans`;
-const EXEC_SERVER_FOLDER = "test/integration/mongodb/app";
+const EXEC_SERVER_FOLDER = 'test/integration/mongodb/app';
 const TEST_TIMEOUT = 300000;
 const WAIT_ON_TIMEOUT = 80000;
 const INTEGRATION_NAME = `mongodb`;
-const INSERT_CMD = "mongodb.insert";
+const INSERT_CMD = 'mongodb.insert';
 const FIND_CMD = 'mongodb.find';
 const UPDATE_CMD = 'mongodb.update';
 const REMOVE_CMD = 'mongodb.remove';
 const CREATE_INDEX_CMD = 'mongodb.createIndexes';
-const DELETE_CMD = "mongodb.delete";
+const DELETE_CMD = 'mongodb.delete';
 const expectedIndexStatement = expect.stringMatching(/"createIndexes":"insertOne","indexes":\[{"name":"a_1","key"/);
 
 
@@ -46,10 +46,10 @@ describe({
                     await callContainer(port, 'stop-mongodb', 'get');
                 }
             } catch (e) {
-                console.warn("afterEach, could not stop mongodb docker container", e)
+                console.warn('afterEach, could not stop "mongodb" docker container', e)
             }
             kill(app.pid, 'SIGHUP');
-            console.info("afterEach, stop child process")
+            console.info('afterEach, stop child process')
         }
     });
 
@@ -64,7 +64,7 @@ describe({
             }
         }, async (exporterFile) => {
             // start server
-            app = getStartedApp(EXEC_SERVER_FOLDER, INTEGRATION_NAME, exporterFile, {OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT: "4096"});
+            app = getStartedApp(EXEC_SERVER_FOLDER, INTEGRATION_NAME, exporterFile, {OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT: '4096'});
 
             port = await new Promise((resolve, reject) => {
                 app.stdout.on('data', (data) => {
@@ -80,13 +80,13 @@ describe({
                         delay: 20000,
                         log: true,
                         validateStatus: function (status) {
-                            console.debug("server status:", status);
+                            console.debug('server status:', status);
                             return status >= 200 && status < 300; // default if not provided
                         },
                     },
                     async function (err) {
                         if (err) {
-                            console.error("inside waitOn", err);
+                            console.error('inside waitOn', err);
                             return reject(err)
                         } else {
                             console.info('Got a response from server');
@@ -115,10 +115,10 @@ describe({
             let resourceAttributes = getExpectedResourceAttributes();
 
             expect(insertSpan).toMatchObject(getExpectedSpan(INSERT_CMD, resourceAttributes, expect.stringMatching(/"a":1,"_id":/)));
-            expect(findSpan).toMatchObject(getExpectedSpanWithParent(FIND_CMD, resourceAttributes, "{\"a\":1}"));
-            expect(updateSpan).toMatchObject(getExpectedSpanWithParent(UPDATE_CMD, resourceAttributes, "{\"a\":1}"));
-            expect(removeSpan).toMatchObject(getExpectedSpanWithParent(REMOVE_CMD, resourceAttributes, "{\"b\":1}"), "$cmd");
-            expect(indexSpan).toMatchObject(getExpectedSpanWithParent(CREATE_INDEX_CMD, resourceAttributes, expectedIndexStatement, "$cmd"));
+            expect(findSpan).toMatchObject(getExpectedSpanWithParent(FIND_CMD, resourceAttributes, '{"a":1}'));
+            expect(updateSpan).toMatchObject(getExpectedSpanWithParent(UPDATE_CMD, resourceAttributes, '{"a":1}'));
+            expect(removeSpan).toMatchObject(getExpectedSpanWithParent(REMOVE_CMD, resourceAttributes, '{"b":1}'), '$cmd');
+            expect(indexSpan).toMatchObject(getExpectedSpanWithParent(CREATE_INDEX_CMD, resourceAttributes, expectedIndexStatement, '$cmd'));
         }
     );
 
@@ -133,7 +133,7 @@ describe({
             }
         }, async (exporterFile) => {
             // //start server
-            app = getStartedApp(EXEC_SERVER_FOLDER, INTEGRATION_NAME, exporterFile, {OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT: "4096"});
+            app = getStartedApp(EXEC_SERVER_FOLDER, INTEGRATION_NAME, exporterFile, {OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT: '4096'});
 
             port = await new Promise((resolve, reject) => {
                 app.stdout.on('data', (data) => {
@@ -151,13 +151,13 @@ describe({
                         simultaneous: 1,
                         log: true,
                         validateStatus: function (status) {
-                            console.debug("server status:", status);
+                            console.debug('server status:', status);
                             return status >= 200 && status < 300; // default if not provided
                         },
                     },
                     async function (err) {
                         if (err) {
-                            console.error("inside waitOn", err);
+                            console.error('inside waitOn', err);
                             return reject(err)
                         } else {
                             console.info('Got a response from server');
@@ -186,12 +186,12 @@ describe({
             let resourceAttributes = getExpectedResourceAttributes();
 
             expect(insertSpan).toMatchObject(getExpectedSpan(INSERT_CMD, resourceAttributes, expect.stringMatching(/"a":1,"_id":/)));
-            expect(findSpan).toMatchObject(getExpectedSpanWithParent(FIND_CMD, resourceAttributes, "{\"find\":\"insertOne\",\"filter\":{\"a\":1}}"));
-            const expectedUpdateStatement = "{\"update\":\"insertOne\",\"updates\":[{\"q\":{\"a\":1},\"u\":{\"$set\":{\"b\":1}}}],\"ordered\":true}";
+            expect(findSpan).toMatchObject(getExpectedSpanWithParent(FIND_CMD, resourceAttributes, '{"find":"insertOne","filter":{"a":1}}'));
+            const expectedUpdateStatement = '{"update":"insertOne","updates":[{"q":{"a":1},"u":{"$set":{"b":1}}}],"ordered":true}';
             expect(updateSpan).toMatchObject(getExpectedSpanWithParent(UPDATE_CMD, resourceAttributes, expectedUpdateStatement));
-            const expectedDeleteStatement = "{\"delete\":\"insertOne\",\"deletes\":[{\"q\":{\"b\":1},\"limit\":0}],\"ordered\":true}";
+            const expectedDeleteStatement = '{"delete":"insertOne","deletes":[{"q":{"b":1},"limit":0}],"ordered":true}';
             expect(removeSpan).toMatchObject(getExpectedSpanWithParent(DELETE_CMD, resourceAttributes, expectedDeleteStatement));
-            expect(indexSpan).toMatchObject(getExpectedSpanWithParent(CREATE_INDEX_CMD, resourceAttributes, expectedIndexStatement, "$cmd"));
+            expect(indexSpan).toMatchObject(getExpectedSpanWithParent(CREATE_INDEX_CMD, resourceAttributes, expectedIndexStatement, '$cmd'));
         }
     );
 });

--- a/test/integration/mongodb/mongodbTestUtils.js
+++ b/test/integration/mongodb/mongodbTestUtils.js
@@ -1,4 +1,4 @@
-import fs from "fs";
+import fs from 'fs';
 
 export function getSpanByName(spans, spanName) {
     return spans.find((span) => span.name === spanName);
@@ -11,7 +11,7 @@ export function getInstrumentationSpansFromFile(filePath) {
         lines.length > 2 &&
         lines[0].startsWith('{"traceId"') &&
         lines[1].startsWith('{"traceId"') &&
-        lines.filter((line) => line.includes('"name":"mongodb') && !line.includes("mongodb.isMaster")).length === 5
+        lines.filter((line) => line.includes('"name":"mongodb') && !line.includes('mongodb.isMaster')).length === 5
     ) {
         return lines
     }
@@ -19,21 +19,21 @@ export function getInstrumentationSpansFromFile(filePath) {
 
 export function getExpectedResourceAttributes() {
     return {
-        "service.name": "mongodb",
-        "telemetry.sdk.language": "nodejs",
-        "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version":  expect.any(String),
-        "framework": "node",
+        'service.name': 'mongodb',
+        'telemetry.sdk.language': 'nodejs',
+        'telemetry.sdk.name': 'opentelemetry',
+        'telemetry.sdk.version':  expect.any(String),
+        'framework': 'node',
         'process.environ': expect.jsonMatching(
             expect.objectContaining({
-                "OTEL_SERVICE_NAME": "mongodb",
+                'OTEL_SERVICE_NAME': 'mongodb',
             })),
         'lumigo.distro.version': expect.stringMatching(/1\.\d+\.\d+/),
         'process.pid': expect.any(Number),
-        "process.executable.name": "node",
+        'process.executable.name': 'node',
         'process.runtime.version': expect.stringMatching(/\d+\.\d+\.\d+/),
-        "process.runtime.name": "nodejs",
-        "process.runtime.description": "Node.js",
+        'process.runtime.name': 'nodejs',
+        'process.runtime.description': 'Node.js',
     };
 }
 
@@ -49,9 +49,9 @@ export function getExpectedSpan(nameSpanAttr, resourceAttributes, dbStatement) {
             attributes: resourceAttributes
         },
         attributes: {
-            'db.system': "mongodb",
-            'db.name': "myProject",
-            'db.mongodb.collection': "insertOne",
+            'db.system': 'mongodb',
+            'db.name': 'myProject',
+            'db.mongodb.collection': 'insertOne',
             'db.statement': dbStatement,
         },
         status: {
@@ -61,7 +61,7 @@ export function getExpectedSpan(nameSpanAttr, resourceAttributes, dbStatement) {
     };
 }
 
-export function getExpectedSpanWithParent(nameSpanAttr, resourceAttributes, dbStatement, dbCollection="insertOne") {
+export function getExpectedSpanWithParent(nameSpanAttr, resourceAttributes, dbStatement, dbCollection='insertOne') {
     return {
         traceId: expect.any(String),
         parentId: expect.any(String),
@@ -74,8 +74,8 @@ export function getExpectedSpanWithParent(nameSpanAttr, resourceAttributes, dbSt
             attributes: resourceAttributes
         },
         attributes: {
-            'db.system': "mongodb",
-            'db.name': "myProject",
+            'db.system': 'mongodb',
+            'db.name': 'myProject',
             'db.mongodb.collection': dbCollection,
             'db.statement': dbStatement,
         },
@@ -87,5 +87,5 @@ export function getExpectedSpanWithParent(nameSpanAttr, resourceAttributes, dbSt
 }
 
 export function getFilteredSpans(spans) {
-    return spans.filter(span => span.name.includes("mongodb") && !span.name.includes("mongodb.isMaster"));
+    return spans.filter(span => span.name.includes('mongodb') && !span.name.includes('mongodb.isMaster'));
 }


### PR DESCRIPTION
Refactor the way we activate instrumentation so that it happens only if the tracer is actually initialized. Log to debug which packages are instrumented.