### PR TITLE
fix: reimplement FileSpanExporter to use async APIs

### DIFF
--- a/src/exporters/FileSpanExporter.test.ts
+++ b/src/exporters/FileSpanExporter.test.ts
@@ -1,4 +1,8 @@
-import { BasicTracerProvider, ReadableSpan, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import {
+  BasicTracerProvider,
+  ReadableSpan,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
 import { Span, SpanKind, SpanStatusCode, TraceFlags } from '@opentelemetry/api';
 import mock from 'mock-fs';
 
@@ -124,7 +128,9 @@ describe('FileSpanExporter tests', () => {
     await exporterUnderTest.shutdown();
 
     expect(spyShutdown).toHaveBeenCalledTimes(1);
-    expect(spyLogger.mock.calls[0][0]).toMatch(/An error occured while exporting the spandump to file.*/);
+    expect(spyLogger.mock.calls[0][0]).toMatch(
+      /An error occured while exporting the spandump to file.*/
+    );
   });
 });
 
@@ -149,5 +155,5 @@ const testSpan: ReadableSpan = {
   resource: Resource.EMPTY,
   instrumentationLibrary: {
     name: 'testScope',
-  }
+  },
 };

--- a/src/exporters/FileSpanExporter.ts
+++ b/src/exporters/FileSpanExporter.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import fs from 'fs';
+import { FileHandle, lstat, open, realpath } from 'fs/promises';
 
-import { ExportResult, ExportResultCode, hrTimeToMicroseconds } from '@opentelemetry/core';
+import { BindOnceFuture, ExportResult, ExportResultCode, hrTimeToMicroseconds } from '@opentelemetry/core';
 import { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
 import { logger } from '../logging';
 
@@ -28,16 +28,21 @@ import { logger } from '../logging';
 
 /* eslint-disable no-console */
 export class FileSpanExporter implements SpanExporter {
-  private _fd: number;
-  private readonly _file: string;
-  private _shutdownOnce: BindOnceFuture<void>;
+  private readonly file: string;
+  private _fd: FileHandle;
+  private readonly _shutdownOnce: BindOnceFuture<void>;
 
   constructor(file: string) {
-    this._file = file;
-    this._fd = fs.openSync(file, 'w');
+    this.file = file;
+    this._shutdownOnce = new BindOnceFuture(this._shutdown.bind(this), this);
+  }
 
-    this.shutdown = this.shutdown.bind(this);
-    this._shutdownOnce = new BindOnceFuture(this._shutdown, this);
+  private async getFileHandleOrOpen(): Promise<FileHandle> {
+    if (!this._fd) {
+      this._fd = await open(this.file, 'w+');
+    }
+
+    return this._fd;
   }
 
   /**
@@ -46,7 +51,30 @@ export class FileSpanExporter implements SpanExporter {
    * @param resultCallback
    */
   export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
-    return this._sendSpans(spans, resultCallback);
+    if (!spans || !spans.length) {
+      return resultCallback({
+          code: ExportResultCode.SUCCESS,
+      });
+    }
+
+    this.getFileHandleOrOpen().then(async (fileHandle) => {
+      const json = spans
+        .map(span => JSON.stringify(this._exportInfo(span), undefined, 0))
+        .join('\n') + '\n';
+
+      fileHandle.appendFile(json).then(() => (
+        resultCallback({
+          code: ExportResultCode.SUCCESS,
+        })
+      ));
+    }).catch(err => {
+      logger.error(`An error occured while exporting the spandump to file '${this.file}'`, err);
+
+      return resultCallback({
+        code: ExportResultCode.FAILED,
+        error: err,
+      });
+    });
   }
 
   /**
@@ -69,34 +97,6 @@ export class FileSpanExporter implements SpanExporter {
     };
   }
 
-  /**
-   * Store spans in file
-   * @param spans
-   * @param done
-   */
-  private _sendSpans(spans: ReadableSpan[], done?: (result: ExportResult) => void): void {
-    let json = '';
-    for (const span of spans) {
-      json += JSON.stringify(this._exportInfo(span), undefined, 0);
-      json += '\n';
-    }
-
-    fs.appendFile(this._fd, json, async (err) => {
-      if (done) {
-        if (err) {
-          return done({
-            code: ExportResultCode.FAILED,
-            error: err,
-          });
-        } else {
-          fs.closeSync(this._fd);
-          this._fd = fs.openSync(this._file, 'a');
-          return done({ code: ExportResultCode.SUCCESS });
-        }
-      }
-    });
-  }
-
   forceFlush(): Promise<void> {
     if (this._shutdownOnce.isCalled) {
       return this._shutdownOnce.promise;
@@ -114,84 +114,32 @@ export class FileSpanExporter implements SpanExporter {
   /**
    * Called by _shutdownOnce with BindOnceFuture
    */
-  private _shutdown(): Promise<void> {
-    return Promise.resolve()
-      .then(() => {
-        return this._flushAll();
-      })
-      .finally(() => {
-        if (this._fd) {
-          fs.closeSync(this._fd);
-        }
-      });
-  }
-
-  private _flushAll(): Promise<void> {
-    return Promise.resolve().then(() => {
+  private async _shutdown(): Promise<void> {
+    return await this._flushAll().finally(async () => {
       if (this._fd) {
+        /*
+        * Do not close block and character devices like `/dev/stdout` or `/dev/stderr`.
+        * We need to resolve symbolic links until we get to the actual file, e.g.,
+        * `/dev/stdout` -> `/proc/self/fd/1` -> `/dev/pts/0`.
+        */
         try {
-          return fs.fdatasyncSync(this._fd);
-        } catch (e) {
-          logger.error(`Cannot export log spandump`, e);
+          const realPath = await realpath(this.file);
+          const stats = await lstat(realPath);
+
+          if (stats.isFile()) {
+            await this._fd.close();
+          }
+        } catch (err) {
+          logger.error(`An error occured while shutting down the spandump exporter to file '${this.file}'`, err);
         }
       }
     });
   }
-}
 
-// From https://github.com/open-telemetry/opentelemetry-js/blob/d61f7bee0f7f60fed794d956e122decd0ce6748f/packages/opentelemetry-core/src/utils/callback.ts,
-// TODO Replace with the opentelemetry-js SDK version when we upgrade
-class BindOnceFuture<R, This = unknown, T extends (this: This, ...args: unknown[]) => R = () => R> {
-  private _isCalled = false;
-  private _deferred = new Deferred<R>();
-  constructor(private _callback: T, private _that: This) {}
-
-  get isCalled() {
-    return this._isCalled;
-  }
-
-  get promise() {
-    return this._deferred.promise;
-  }
-
-  call(...args: Parameters<T>): Promise<R> {
-    if (!this._isCalled) {
-      this._isCalled = true;
-      try {
-        Promise.resolve(this._callback.call(this._that, ...args)).then(
-          (val) => this._deferred.resolve(val),
-          (err) => this._deferred.reject(err)
-        );
-      } catch (err) {
-        this._deferred.reject(err);
-      }
-    }
-    return this._deferred.promise;
-  }
-}
-
-// From https://github.com/open-telemetry/opentelemetry-js/blob/d61f7bee0f7f60fed794d956e122decd0ce6748f/packages/opentelemetry-core/src/utils/promise.ts,
-// TODO Replace with the opentelemetry-js SDK version when we upgrade
-class Deferred<T> {
-  private _promise: Promise<T>;
-  private _resolve!: (val: T) => void;
-  private _reject!: (error: unknown) => void;
-  constructor() {
-    this._promise = new Promise((resolve, reject) => {
-      this._resolve = resolve;
-      this._reject = reject;
+  private _flushAll = async (): Promise<void> => {
+    return await this._fd?.sync().catch(err => {
+      logger.error(`An error occured while flushing the spandump to file '${this.file}'`, err);
     });
   }
 
-  get promise() {
-    return this._promise;
-  }
-
-  resolve(val: T) {
-    this._resolve(val);
-  }
-
-  reject(err: unknown) {
-    this._reject(err);
-  }
 }


### PR DESCRIPTION
Also: do not to close the file descriptor on exit unless it's a regular file.

Fixes #167