### PR TITLE
chore: use object spread for shallow clone of process.env

### DIFF
--- a/src/resources/detectors/ProcessEnvironmentDetector.ts
+++ b/src/resources/detectors/ProcessEnvironmentDetector.ts
@@ -13,7 +13,7 @@ export class ProcessEnvironmentDetector implements Detector {
            * in a way that does not play nice with the way we use Symbols in the
            * scrubbing process.
            */
-          Object.create(process.env),
+          { ...process.env },
           ScrubContext.PROCESS_ENVIRONMENT,
           getResourceAttributeMaxLength()
         ),


### PR DESCRIPTION
The use of `{ ... obj }` to shallow-clone `obj` is more reliable than `Object.create`.