### PR TITLE
fix: sync published version from main package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3321,6 +3321,20 @@
       "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
       "dev": true
     },
+    "@semantic-release/exec": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-6.0.3.tgz",
+      "integrity": "sha512-bxAq8vLOw76aV89vxxICecEa8jfaWwYITw6X74zzlO0mc/Bgieqx9kBRz9z96pHectiTAtsCwsQcUyLYWnp3VQ==",
+      "dev": true,
+      "requires": {
+        "@semantic-release/error": "^3.0.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^5.0.0",
+        "lodash": "^4.17.4",
+        "parse-json": "^5.0.0"
+      }
+    },
     "@semantic-release/git": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-10.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumigo/opentelemetry",
-  "version": "1.48.0",
+  "version": "$next_version",
   "description": "Lumigo wrapper to trace distributed architecture",
   "private": false,
   "types": "dist/src/distro.js",
@@ -75,6 +75,7 @@
     "@grpc/grpc-js": "^1.9.0",
     "@jest/globals": "^29.4.0",
     "@semantic-release/changelog": "^6.0.1",
+    "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^8.0.5",
     "@types/deasync": "^0.1.5",
@@ -134,7 +135,13 @@
       "@semantic-release/release-notes-generator",
       "@semantic-release/npm",
       "@semantic-release/git",
-      "@semantic-release/github"
+      "@semantic-release/github",
+      [
+        "@semantic-release/exec",
+        {
+          "prepareCmd": "./scripts/update_dist_version.sh ${nextRelease.version}"
+        }
+      ]
     ]
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumigo/opentelemetry",
-  "version": "$next_version",
+  "version": "1.48.0",
   "description": "Lumigo wrapper to trace distributed architecture",
   "private": false,
   "types": "dist/src/distro.js",

--- a/scripts/update_dist_version.sh
+++ b/scripts/update_dist_version.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# Expected to come from running the script with `nextRelease.version` during a semantic-release hook run
 next_version=$1
 
 pushd ./dist

--- a/scripts/update_dist_version.sh
+++ b/scripts/update_dist_version.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Expected to come from running the script with `nextRelease.version` during a semantic-release hook run
+next_version=$1
+
+pushd ./dist
+if [ ! -f "package.json" ]; then
+  echo "File dist/package.json found."
+  exit 1
+fi
+
+jq ".version = \"$next_version\"" package.json > package.tmp.json && mv package.tmp.json package.json
+popd


### PR DESCRIPTION
Fixes https://lumigo.atlassian.net/browse/RD-13766

TL;DR:

When the JS distro loads, it prints the version from `src/dist/package.json`, which holds one version behind the one in the main package.json that gets updated and pushed to git by `semantic-release`.
This change syncs that version to the inner package.json as well, before the publish to `npm`, therefore the correct value will be used from now on.