### PR TITLE
feat: simpler sync-init sequence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2592,14 +2592,6 @@
             "shimmer": "^1.2.1"
           }
         },
-        "@types/ioredis4": {
-          "version": "npm:@types/ioredis@4.28.10",
-          "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.28.10.tgz",
-          "integrity": "sha512-69LyhUgrXdgcNDv7ogs1qXZomnfOEnSmrmMFqKgt1XMJxmoOSG/u3wYy13yACIfKuMJ8IhKgHafDO3sx19zVQQ==",
-          "requires": {
-            "@types/node": "*"
-          }
-        },
         "import-in-the-middle": {
           "version": "1.4.2",
           "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
@@ -5328,12 +5320,6 @@
         "@types/node": "*"
       }
     },
-    "@types/deasync": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@types/deasync/-/deasync-0.1.5.tgz",
-      "integrity": "sha512-mLov/tw+fOX4ZsrT9xuHOJv8xToOpNsp6W4gp8VDHy2qniJ58izyOzHlisnz5r8HdZ+WItDHtANWZy/W0JEJwg==",
-      "dev": true
-    },
     "@types/docker-modem": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
@@ -5399,6 +5385,14 @@
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
       "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
       "dev": true
+    },
+    "@types/ioredis4": {
+      "version": "npm:@types/ioredis@4.28.10",
+      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.28.10.tgz",
+      "integrity": "sha512-69LyhUgrXdgcNDv7ogs1qXZomnfOEnSmrmMFqKgt1XMJxmoOSG/u3wYy13yACIfKuMJ8IhKgHafDO3sx19zVQQ==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -6512,14 +6506,6 @@
       "dev": true,
       "optional": true
     },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -7396,15 +7382,6 @@
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
       "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
       "dev": true
-    },
-    "deasync": {
-      "version": "0.1.30",
-      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.30.tgz",
-      "integrity": "sha512-OaAjvEQuQ9tJsKG4oHO9nV1UHTwb2Qc2+fadB0VeVtD0Z9wiG1XPGLJ4W3aLhAoQSYTaLROFRbd5X20Dkzf7MQ==",
-      "requires": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^1.7.1"
-      }
     },
     "debug": {
       "version": "4.3.7",
@@ -8409,11 +8386,6 @@
       "requires": {
         "flat-cache": "^3.0.4"
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "fill-range": {
       "version": "7.1.1",
@@ -11337,11 +11309,6 @@
       "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
       "integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
       "dev": true
-    },
-    "node-addon-api": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="
     },
     "node-emoji": {
       "version": "1.11.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@opentelemetry/semantic-conventions": "1.17.1",
     "@opentelemetry/winston-transport": "0.2.0",
     "@prisma/instrumentation": "^4.14.0",
-    "deasync": "^0.1.30",
     "opentelemetry-instrumentation-express": "0.39.1",
     "opentelemetry-instrumentation-kafkajs": "^0.39.1",
     "shimmer": "^1.2.1"
@@ -78,7 +77,6 @@
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^8.0.5",
-    "@types/deasync": "^0.1.5",
     "@types/express": "^4.17.8",
     "@types/jest": "^29.5.1",
     "@types/kafkajs": "^1.9.0",

--- a/src/distro-sync-init.ts
+++ b/src/distro-sync-init.ts
@@ -1,21 +1,12 @@
 import { init, LumigoSdkInitialization } from './distro';
-import deasync from 'deasync';
+import { logger } from './logging';
 
-let done = false;
 let lumigoSdk: LumigoSdkInitialization | undefined;
 
-init
-  .then((initializedLumigoSdk) => {
-    lumigoSdk = initializedLumigoSdk;
-  })
-  .catch((err) => {
-    console.error(`Lumigo JS distro synchronous bootstrap failed: ${err}`);
-  })
-  .finally(() => {
-    done = true;
-  });
-
-deasync.loopWhile(() => !done);
+(async () => {
+  logger.info('Lumigo OpenTelemetry Distro synchronous bootstrapping starting...');
+  lumigoSdk = await init;
+})();
 
 /*
   The `export =` syntax makes sure that using the sync endpoint from both TS and JS will return the same object structure:


### PR DESCRIPTION
This setup gets rid of the `deasync` package in favor of natively using an async-[IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE).
That solves another issue with the `deasync` package being compiled on distro installation, and requires pre-compiled binaries that are missing for `arm64` architectures.